### PR TITLE
get_user_tweets api may return only result_count. newest_id and oldest_id may be None

### DIFF
--- a/src/meta/tweets.rs
+++ b/src/meta/tweets.rs
@@ -4,8 +4,10 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct TweetsMeta {
     pub result_count: usize,
-    pub newest_id: String,
-    pub oldest_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub newest_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub oldest_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub next_token: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
get_user_tweets api may return only result_count(result_count=0). In those cases `newest_id` and `oldest_id` are None. 
E.g. send a `get_user_tweets` request with `until_id` set to the user's first tweet.  

In those cases decoding errors with the TweetsMeta happens. 

```error decoding response body: missing field newest_id at line 1 column 26"```

Changing newest_id and oldest_id Option<String> fixes the issue. 