### PR TITLE
Setting AnnotationEntity start to isize, as -1 was returned in payload.

### DIFF
--- a/src/data/entity.rs
+++ b/src/data/entity.rs
@@ -42,7 +42,7 @@ pub struct HashtagEntity {
 #[cfg_attr(feature = "arbitrary_precision", derive(Eq))]
 pub struct AnnotationEntity {
     pub start: isize,
-    pub end: usize,
+    pub end: isize,
     #[cfg(feature = "arbitrary_precision")]
     pub probability: Number,
     #[cfg(not(feature = "arbitrary_precision"))]

--- a/src/data/entity.rs
+++ b/src/data/entity.rs
@@ -41,7 +41,7 @@ pub struct HashtagEntity {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(feature = "arbitrary_precision", derive(Eq))]
 pub struct AnnotationEntity {
-    pub start: usize,
+    pub start: isize,
     pub end: usize,
     #[cfg(feature = "arbitrary_precision")]
     pub probability: Number,


### PR DESCRIPTION
AnnotationEntity `start` is set to be a `usize`, but I've seen `start` being returned as `-1`
This fix is to convert `start` to an `isize`.
```
      "entities": {
        "annotations": [
          {
            "start": -1,
            "end": 97,
            "probability": 0.6735,
            "type": "Other",
            "normalized_text": "� Exc"
          }
        ],
        "mentions": [
          {
            "start": 3,
            "end": 11,
            "username": "jscarto",
            "id": "16692909"
          }
        ]
      },```