### PR TITLE
Fix for "connection closed before message completed" error

### DIFF
--- a/src/api/base.rs
+++ b/src/api/base.rs
@@ -21,7 +21,7 @@ where
 {
     pub fn new(auth: A) -> Self {
         Self {
-            client: Client::new(),
+            client: Client::builder().pool_max_idle_per_host(0).build().unwrap(),
             base_url: Url::parse("https://api.twitter.com/2/").unwrap(),
             auth: Arc::new(auth),
         }


### PR DESCRIPTION
I was regularly seeing a  "connection closed before message completed" error, when making API requests.

This fixes the issue, based on my testing.

Source:
https://github.com/hyperium/hyper/issues/2136#issuecomment-861826148
&
https://github.com/wyyerd/stripe-rs/pull/172