### PR TITLE
Allow null expanded_url and display_url in UrlEntity

### DIFF
--- a/src/data/entity.rs
+++ b/src/data/entity.rs
@@ -17,8 +17,10 @@ pub struct UrlEntity {
     pub start: usize,
     pub end: usize,
     pub url: String,
-    pub expanded_url: String,
-    pub display_url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expanded_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display_url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub images: Option<Vec<UrlImage>>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/data/entity.rs
+++ b/src/data/entity.rs
@@ -14,8 +14,10 @@ pub struct UrlImage {
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct UrlEntity {
-    pub start: usize,
-    pub end: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub start: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub end: Option<usize>,
     pub url: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expanded_url: Option<String>,


### PR DESCRIPTION
Both `expanded_url` and `display_url` can be null in a URL entity. Without these changes, some tweets will fail to deserialize.